### PR TITLE
feat: update usagi type shopify

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "test:core": "bun --filter '@usagi-ts/core' test",
     "test:cli": "bun run --filter '@usagi-ts/cli' test",
     "generate-types": "bun run scripts/generate-types.ts",
-    "usagi": "bun run --filter '@usagi-ts/cli' ./bin/usagi-ts.js",
-    "prepublishOnly": "bun run generate-types && bun run build"
+    "usagi": "bun run ./packages/cli/bin/usagi-ts.js"
   },
   "dependencies": {
     "@usagi-ts/core": "workspace:*"

--- a/packages/core/src/schema.json
+++ b/packages/core/src/schema.json
@@ -82,6 +82,8 @@
             "zh",
             "crh-UA",
             "crh",
+            "cs-CZ",
+            "cs",
             "nb",
             "no",
             "nl-NL",
@@ -91,7 +93,9 @@
             "fa-IR",
             "sv-SE",
             "de-LU",
-            "fr-FR"
+            "fr-FR",
+            "bg-BG",
+            "bg"
           ],
           "default": "en-US",
           "description": "Set the language for reviews by using the corresponding ISO language code."
@@ -272,7 +276,7 @@
                   },
                   "instructions": {
                     "type": "string",
-                    "maxLength": 3000,
+                    "maxLength": 20000,
                     "description": "Provides specific additional guidelines for code review based on file paths."
                   }
                 },
@@ -825,6 +829,19 @@
                   "additionalProperties": false,
                   "default": {},
                   "description": "OXC is a JavaScript/TypeScript linter written in Rust."
+                },
+                "shopifyThemeCheck": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean",
+                      "default": true,
+                      "description": "Enable Shopify Theme Check | A linter for Shopify themes that helps you follow Shopify theme & Liquid best practices | cli 3.77.1 | theme 3.58.2"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "default": {},
+                  "description": "Configuration for Shopify Theme Check to ensure theme quality and best practices"
                 }
               },
               "additionalProperties": false,
@@ -1103,6 +1120,8 @@
                     "zh",
                     "crh-UA",
                     "crh",
+                    "cs-CZ",
+                    "cs",
                     "nb",
                     "no",
                     "nl-NL",
@@ -1112,7 +1131,9 @@
                     "fa-IR",
                     "sv-SE",
                     "de-LU",
-                    "fr-FR"
+                    "fr-FR",
+                    "bg-BG",
+                    "bg"
                   ],
                   "default": "en-US",
                   "description": "Set the language for docstrings by using the corresponding ISO language code."

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -80,6 +80,8 @@ export interface CodeRabbitConfig {
     | 'zh'
     | 'crh-UA'
     | 'crh'
+    | 'cs-CZ'
+    | 'cs'
     | 'nb'
     | 'no'
     | 'nl-NL'
@@ -89,7 +91,9 @@ export interface CodeRabbitConfig {
     | 'fa-IR'
     | 'sv-SE'
     | 'de-LU'
-    | 'fr-FR';
+    | 'fr-FR'
+    | 'bg-BG'
+    | 'bg';
   /**
    * Set the tone of reviews and chat. Example: 'You must use talk like Mr. T. I pity the fool who doesn't!'
    */
@@ -578,6 +582,15 @@ export interface CodeRabbitConfig {
          */
         enabled?: boolean;
       };
+      /**
+       * Configuration for Shopify Theme Check to ensure theme quality and best practices
+       */
+      shopifyThemeCheck?: {
+        /**
+         * Enable Shopify Theme Check | A linter for Shopify themes that helps you follow Shopify theme & Liquid best practices | cli 3.77.1 | theme 3.58.2
+         */
+        enabled?: boolean;
+      };
     };
   };
   chat?: {
@@ -738,6 +751,8 @@ export interface CodeRabbitConfig {
         | 'zh'
         | 'crh-UA'
         | 'crh'
+        | 'cs-CZ'
+        | 'cs'
         | 'nb'
         | 'no'
         | 'nl-NL'
@@ -747,7 +762,9 @@ export interface CodeRabbitConfig {
         | 'fa-IR'
         | 'sv-SE'
         | 'de-LU'
-        | 'fr-FR';
+        | 'fr-FR'
+        | 'bg-BG'
+        | 'bg';
     };
   };
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for Czech ("cs", "cs-CZ") and Bulgarian ("bg", "bg-BG") language options in review and docstring generation settings.
	- Introduced configuration for Shopify Theme Check, allowing users to enable or disable this linter for Shopify themes and Liquid best practices.
- **Enhancements**
	- Increased the maximum allowed length for path-specific instructions from 3,000 to 20,000 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->